### PR TITLE
Add Lua to languageIds

### DIFF
--- a/chalice-icon-theme.json
+++ b/chalice-icon-theme.json
@@ -220,6 +220,7 @@
     "yml": "script.inverse"
   },
   "languageIds": {
+    "lua": "code.inverse",
     "docker": "script.inverse"
   },
   "light": {
@@ -332,6 +333,7 @@
       "yml": "script.normal"
     },
     "languageIds": {
+      "lua": "code.normal",
       "docker": "script.normal"
     }
   },


### PR DESCRIPTION
I have a bunch of Lua files that don't follow the .lua extension (Defold script files). They're properly marked with the Lua language Id by my workspace settings, but I would like the icon theme to pick them up as code as well, hence this PR.