### PR TITLE
Register the CommonJS files as code

### DIFF
--- a/chalice-icon-theme.json
+++ b/chalice-icon-theme.json
@@ -248,6 +248,7 @@
       "js": "code.normal",
       "jsx": "bracket.normal",
       "mjs": "code.normal",
+      "cjs": "code.normal",
       "svg": "bracket.normal",
       "html": "bracket.normal",
       "htm": "bracket.normal",

--- a/chalice-icon-theme.json
+++ b/chalice-icon-theme.json
@@ -133,6 +133,7 @@
     "js": "code.inverse",
     "jsx": "bracket.inverse",
     "mjs": "code.inverse",
+    "cjs": "code.inverse",
     "svg": "bracket.inverse",
     "html": "bracket.inverse",
     "htm": "bracket.inverse",


### PR DESCRIPTION
`.cjs` stands for CommonJS, similarly to `.mjs` for ES Modules.