### PR TITLE
vsce: ignore more files

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,7 @@
+.clj-kondo/
 .gitignore
+.github/
+.lsp/
 .shadow-cljs/
 .vscode/
 assets/


### PR DESCRIPTION
the published extension contains caches from clj-kondo and an lsp, the latter of which compresses very well but expands to about 100MB in size

this change to the .vscodeignore should remove both, and also the github metadata which i don't think the extension needs